### PR TITLE
Resolve startup errors

### DIFF
--- a/binglide/mixers.py
+++ b/binglide/mixers.py
@@ -15,7 +15,7 @@ class ChannelMixer(object):
 
     def __call__(self, colored, data, coefs):
         for c in self.channels:
-            colored[..., c] += data * coefs[c]
+            colored[..., c] = colored[..., c] + (data * coefs[c])
 
 mix_greys = Renderer.register_mixer(None)(
     ChannelMixer(True, True, True))

--- a/binglide/projectors.py
+++ b/binglide/projectors.py
@@ -35,7 +35,7 @@ def proj_scanline(dst, data, shape):
     rshape.append(4)
 
     data = data.reshape((size, 4))
-    data = np.pad(data, ((0, nsize - size), (0, 0)), 'constant')
+    data = np.pad(data, ((0, np.int32(nsize - size)), (0, 0)), 'constant')
     data = data.reshape(rshape, order='F')
 
     return data

--- a/binglide/renderers.py
+++ b/binglide/renderers.py
@@ -315,7 +315,7 @@ class Renderer2D(pg.GraphicsLayoutWidget, Renderer):
     def do_render(self, projected):
         projected = self.rescale(projected)
 
-        self.img.setImage(projected, levels=None)
+        self.img.setImage(projected, levels=[10, 10])
 
         for _ in (1, 2): # No idea why but need to do this twice.
             self.view.setRange(xRange=(0, self.projected.shape[0]),


### PR DESCRIPTION
This is a patch along with issue #8 to initialize without error. My only uncertainty is with `levels` in `self.img.setImage(projected, levels=[10, 10])`. It was `None` formerly but works with this configuration.